### PR TITLE
Fix #1: Count vote twice on reply

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,15 +54,6 @@ async def on_message(message):
 
     if message.content.startswith('$$leaderboard'):
         await leaderboard(conn, client, message, LEADERBOARD_LIMIT)
-
-    if message.reference is not None:
-        try:
-            channel = client.get_channel(message.reference.channel_id)
-            orig_msg = await channel.fetch_message(message.reference.message_id)
-            if orig_msg.author.id != message.author.id and hasRole(orig_msg.author.roles, REQUIRED_ROLE_ID):
-                processVote(message.id, orig_msg.author.id, message.author.id)
-        except discord.NotFound:
-            pass
     
     if message.mentions != []:
         for member in message.mentions:


### PR DESCRIPTION
Replies seem to include mentions of the author replied to.

Removing the reply code will still count replies as a mention but will no longer count them as two votes.

Deleting the message will still result in a 'downvote' so no issue here.