### PR TITLE
Expose REACTION_TO_COMPARE and IGNORED_CHANNELS as env variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,12 +15,19 @@ NOTIFY_USER = os.environ['NOTIFY_USER']
 IGNORED_CHANNELS = [763798356484161569, 772838189920026635,  839229026194423898] if not 'DISCORD_IGNORED_CHANNELS' in os.environ else json.load(os.environ['DISCORD_IGNORED_CHANNELS'])
 # defaults to General, Lumenauts, Report-spam
 
-
-if not (isinstance(REACTION_TO_COMPARE, list) or  len(REACTION_TO_COMPARE) != 0 and not isinstance(REACTION_TO_COMPARE[0], str)):
+if not isinstance(REACTION_TO_COMPARE, list) \
+   or (
+       len(REACTION_TO_COMPARE) != 0 \
+       and not isinstance(REACTION_TO_COMPARE[0], str)\
+      ):
     # REACTION_TO_COMPARE must be str to arr of str; empty array => wildcard 
     print("DISCORD_ALLOWED_REACTION env variable has to be array of strs!")
     exit
-if not isinstance(IGNORED_CHANNELS, list) or (len(IGNORED_CHANNELS) != 0 and not isinstance(IGNORED_CHANNELS[0], int)):
+if not isinstance(IGNORED_CHANNELS, list)\
+   or (
+       len(IGNORED_CHANNELS) != 0\
+       and not isinstance(IGNORED_CHANNELS[0], int)\
+      ):
     # IGNORE_CHANNELS must be array of ints
     print("DISCORD_IGNORED_CHANNELS env variable has to be array of ints!")
     exit

--- a/main.py
+++ b/main.py
@@ -4,12 +4,26 @@ from sqlite3 import Error
 import os
 from helper import *
 from discord_helpers import leaderboard, hasRole
+import json
 
 DATABASE_NAME = 'votes.db'
-REACTION_TO_COMPARE = '🐻'
+REACTION_TO_COMPARE = ['🐻'] if not 'DISCORD_ALLOWED_REACTION' in os.environ else json.loads(os.environ['DISCORD_ALLOWED_REACTION'])
 LEADERBOARD_LIMIT = 10
 BOT_TOKEN = os.environ['DISCORD_BOT_TOKEN']
 REQUIRED_ROLE_ID = os.environ['ROLE_ID']
+NOTIFY_USER = os.environ['NOTIFY_USER']
+IGNORED_CHANNELS = [763798356484161569, 772838189920026635,  839229026194423898] if not 'DISCORD_IGNORED_CHANNELS' in os.environ else json.load(os.environ['DISCORD_IGNORED_CHANNELS'])
+# defaults to General, Lumenauts, Report-spam
+
+
+if not (isinstance(REACTION_TO_COMPARE, list) or  len(REACTION_TO_COMPARE) != 0 and not isinstance(REACTION_TO_COMPARE[0], str)):
+    # REACTION_TO_COMPARE must be str to arr of str; empty array => wildcard 
+    print("DISCORD_ALLOWED_REACTION env variable has to be array of strs!")
+    exit
+if not isinstance(IGNORED_CHANNELS, list) or (len(IGNORED_CHANNELS) != 0 and not isinstance(IGNORED_CHANNELS[0], int)):
+    # IGNORE_CHANNELS must be array of ints
+    print("DISCORD_IGNORED_CHANNELS env variable has to be array of ints!")
+    exit
 
 def create_connection(db_file):
     """ create a database connection to a SQLite database """
@@ -42,15 +56,15 @@ async def on_message(message):
     if message.author == client.user:
         return
 
-    if message.channel.id in [763798356484161569, 772838189920026635,  839229026194423898]: # General, Lumenauts, Report-spam
-        return
-
     if message.content.startswith('$hello'):
         await message.channel.send('Hello!')
 
     if message.content.startswith('$$leaderboard'):
         await leaderboard(conn, client, message, LEADERBOARD_LIMIT)
     
+    if message.channel.id in IGNORED_CHANNELS:
+        return
+
     if message.mentions != []:
         for member in message.mentions:
             if member.id == message.author.id and hasRole(member.roles, REQUIRED_ROLE_ID):
@@ -60,7 +74,14 @@ async def on_message(message):
 @client.event
 async def on_reaction_add(reaction, user):
     channel = reaction.message.channel
-    if reaction.emoji == REACTION_TO_COMPARE and user.id != reaction.message.author.id and hasRole(reaction.message.author.roles, REQUIRED_ROLE_ID):
+    
+    if channel.id in IGNORED_CHANNELS:
+        return
+
+    if (reaction.emoji in REACTION_TO_COMPARE or len(REACTION_TO_COMPARE) == 0)\
+        and user.id != reaction.message.author.id\
+        and hasRole(reaction.message.author.roles, REQUIRED_ROLE_ID)\
+        and user.id != client.user.id:
        processVote(reaction.message.id, reaction.message.author.id, user.id)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Expose `REACTION_TO_COMPARE` and `IGNORED_CHANNELS` as environment variable.

The environment variabels `DISCORD_ALLOWED_REACTION` and `DISCORD_IGNORED_CHANNELS` will be parsed as JSON Array.

If no variable was set, default value from previous version will be used.

Setting an empty array will result in a wildcard.

Also fixes `$$leaderboard` and co. not working in ignored channels.