### PR TITLE
Account for unclaimed balances

### DIFF
--- a/helpers/stellar.py
+++ b/helpers/stellar.py
@@ -34,7 +34,7 @@ def fetch_account_balance(pubKey: str = PUBLIC_KEY) -> float:
             balance = float(b["balance"])
             break
 
-    balance -= 0.5 * (2 + acc["subentry_count"])  # base reserve
+    balance -= 0.5 * (2 + acc["subentry_count"] + acc["num_sponsoring"])  # base reserve
     return balance
 
 


### PR DESCRIPTION
If any balances from the previous week remain unclaimed, they must be accounted for to calculate the available balance for distribution.